### PR TITLE
feat: Exporse get_mut

### DIFF
--- a/src/trie.rs
+++ b/src/trie.rs
@@ -79,6 +79,26 @@ impl<K: Eq + Ord + Clone, V: Clone> Trie<K, V> {
         self.find_node(key).and_then(|node| node.get_value())
     }
 
+    /// Gets the mutable value from the tree by key
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use ptrie::Trie;
+    ///
+    /// let mut t = Trie::new();
+    /// let data = "test".bytes();
+    /// let another_data = "notintest".bytes();
+    /// assert_eq!(t.get_mut(data.clone()), None);
+    /// t.insert(data.clone(), 42);
+    ///
+    /// assert_eq!(t.get_mut(data), Some(42).as_mut());
+    /// assert_eq!(t.get(another_data), None);
+    /// ```
+    pub fn get_mut<I: Iterator<Item = K>>(&mut self, key: I) -> Option<&mut V> {
+        self.find_node_mut(key).and_then(|node| node.get_value_mut())
+    }
+
     /// Sets the value pointed by a key
     ///
     /// # Example

--- a/src/trie_node.rs
+++ b/src/trie_node.rs
@@ -61,6 +61,10 @@ impl<K: Eq + Ord + Clone, V: Clone> TrieNode<K, V> {
         self.value.as_ref()
     }
 
+    pub fn get_value_mut(&mut self) -> Option<&mut V> {
+        self.value.as_mut()
+    }
+
     pub fn may_be_leaf(&self) -> bool {
         self.value.is_some()
     }


### PR DESCRIPTION
Expose `get_mut` method.
This is useful in the following cases:

```rust
// Build the trie
let mut trie = Trie::new();
trie.insert("foo".bytes(), 1);

// Update the trie later
if let Some(value) = trie.get_mut("foo".bytes()) {
  *value += 1;
}

// Search
assert_eq!(trie.get("foo".bytes()), Some(2));
```